### PR TITLE
add automatic backoff-retry for retryable requests

### DIFF
--- a/_examples/monitors/main.go
+++ b/_examples/monitors/main.go
@@ -14,7 +14,7 @@ func main() {
 		RefreshToken: os.Getenv("REFRESH_TOKEN"),
 	}
 
-	client := site24x7.NewClientForConfig(config)
+	client := site24x7.New(config)
 
 	monitors, err := client.Monitors().List()
 	if err != nil {

--- a/backoff/retry.go
+++ b/backoff/retry.go
@@ -1,0 +1,135 @@
+package backoff
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
+)
+
+// HTTPClient is the interface of an http client that is compatible with
+// *http.Client.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// RetryConfig configures the backoff-retry behaviour.
+type RetryConfig struct {
+	MinWait    time.Duration
+	MaxWait    time.Duration
+	MaxRetries int
+	CheckRetry retryablehttp.CheckRetry
+	Backoff    retryablehttp.Backoff
+}
+
+// DefaultRetryConfig is the default config for retrying http requests.
+var DefaultRetryConfig = RetryConfig{
+	MinWait:    1 * time.Second,
+	MaxWait:    30 * time.Second,
+	MaxRetries: 4,
+	CheckRetry: DefaultRetryPolicy,
+	Backoff:    DefaultBackoff,
+}
+
+// retryableClient wraps *retryablehttp.Client to be compatible with the
+// HTTPClient interface.
+type retryableClient struct {
+	*retryablehttp.Client
+}
+
+// WithRetries wraps httpClient with backoff-retry logic.
+func WithRetries(httpClient *http.Client, config *RetryConfig) HTTPClient {
+	cfg := DefaultRetryConfig
+	if config != nil {
+		cfg = *config
+	}
+
+	c := &retryableClient{
+		&retryablehttp.Client{
+			HTTPClient:   httpClient,
+			RetryWaitMin: cfg.MinWait,
+			RetryWaitMax: cfg.MaxWait,
+			RetryMax:     cfg.MaxRetries,
+			CheckRetry:   cfg.CheckRetry,
+			Backoff:      cfg.Backoff,
+		},
+	}
+
+	return c
+}
+
+// Do implements HTTPClient. It is an adapter for *retryablehttp.Client.Do and
+// takes care of wrapping the *http.Request with the custom
+// *retyablehttp.Request type.
+func (c *retryableClient) Do(req *http.Request) (*http.Response, error) {
+	wrappedReq, err := retryablehttp.FromRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Client.Do(wrappedReq)
+}
+
+// DefaultRetryPolicy provides a callback for retryablehttp.Client.CheckRetry, which
+// will retry on connection errors, server errors and request throttling.
+func DefaultRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	// do not retry on context.Canceled or context.DeadlineExceeded
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+
+	if err != nil {
+		return true, err
+	}
+
+	// Check the response code. We retry on 500-range responses to allow the
+	// server time to recover, as 500's are typically not permanent errors and
+	// may relate to outages on the server side. This will catch invalid
+	// response codes as well, like 0 and 999. It will also catch 429
+	// ToManyRequests responses.
+	if resp.StatusCode == 0 || resp.StatusCode == 429 || (resp.StatusCode >= 500 && resp.StatusCode != 501) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// DefaultBackoff provides a callback for retryablehttp.Client.Backoff which will
+// perform exponential backoff based on the attempt number and limited by the
+// provided minimum and maximum durations. On 429 responses it will try to
+// parse the Retry-After header use that value as backoff. Will fallback to
+// exponential backoff if the Retry-After header is not present or cannot be
+// parsed.
+func DefaultBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+	retryAfter, ok := getRetryAfter(resp)
+	if ok && retryAfter > 0 {
+		if retryAfter > max {
+			return max
+		}
+
+		return retryAfter
+	}
+
+	return retryablehttp.DefaultBackoff(min, max, attemptNum, resp)
+}
+
+// getRetryAfter obtains the timeout from the Retry-After header if set. The
+// second return value is true if a valid Retry-After value was found.
+func getRetryAfter(resp *http.Response) (time.Duration, bool) {
+	if resp == nil || resp.Header == nil {
+		return 0, false
+	}
+
+	retryAfter := resp.Header.Get("Retry-After")
+
+	seconds, err := strconv.ParseInt(retryAfter, 10, 64)
+	if err == nil {
+		timeout := time.Duration(seconds) * time.Second
+
+		return timeout, true
+	}
+
+	return 0, false
+}

--- a/backoff/retry_test.go
+++ b/backoff/retry_test.go
@@ -1,0 +1,187 @@
+package backoff
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultRetryPolicy(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctx         context.Context
+		resp        *http.Response
+		err         error
+		expected    bool
+		expectedErr string
+	}{
+		{
+			name: "ctx error should not be retried",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			expected:    false,
+			expectedErr: "context canceled",
+		},
+		{
+			name:        "errors should be retried",
+			err:         errors.New("something went wrong"),
+			expected:    true,
+			expectedErr: "something went wrong",
+		},
+		{
+			name:     "empty status code should be retried",
+			resp:     newResponse(0),
+			expected: true,
+		},
+		{
+			name:     "429 status code should be retried",
+			resp:     newResponse(429),
+			expected: true,
+		},
+		{
+			name:     "5xx status code should be retried",
+			resp:     newResponse(503),
+			expected: true,
+		},
+		{
+			name:     "501 status code should not be retried",
+			resp:     newResponse(501),
+			expected: false,
+		},
+		{
+			name:     "4xx status code should not be retried",
+			resp:     newResponse(400),
+			expected: false,
+		},
+		{
+			name:     "3xx status code should not be retried",
+			resp:     newResponse(302),
+			expected: false,
+		},
+		{
+			name:     "2xx status code should not be retried",
+			resp:     newResponse(200),
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := test.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+
+			retry, err := DefaultRetryPolicy(ctx, test.resp, test.err)
+			if test.expectedErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, test.expectedErr, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, test.expected, retry)
+		})
+	}
+}
+
+func TestDefaultBackoff(t *testing.T) {
+	tests := []struct {
+		name       string
+		min, max   time.Duration
+		attemptNum int
+		resp       *http.Response
+		expected   time.Duration
+	}{
+		{
+			name:       "increasing exponential backoff by attempt",
+			min:        1 * time.Second,
+			max:        30 * time.Second,
+			attemptNum: 3,
+			expected:   8 * time.Second,
+		},
+		{
+			name:       "min exponential backoff on first attempt",
+			min:        1 * time.Second,
+			max:        30 * time.Second,
+			attemptNum: 0,
+			expected:   1 * time.Second,
+		},
+		{
+			name:       "exponential backoff capped by max",
+			min:        1 * time.Second,
+			max:        30 * time.Second,
+			attemptNum: 10,
+			expected:   30 * time.Second,
+		},
+		{
+			name:     "use Retry-After header value",
+			min:      1 * time.Second,
+			max:      30 * time.Second,
+			expected: 3 * time.Second,
+			resp:     withRetryAfter(newResponse(429), "3"),
+		},
+		{
+			name:     "Retry-After capped to max",
+			min:      1 * time.Second,
+			max:      30 * time.Second,
+			expected: 30 * time.Second,
+			resp:     withRetryAfter(newResponse(429), "3600"),
+		},
+		{
+			name:       "Invalid Retry-After falls back to exponential backoff",
+			min:        1 * time.Second,
+			max:        30 * time.Second,
+			attemptNum: 3,
+			expected:   8 * time.Second,
+			resp:       withRetryAfter(newResponse(429), "abc"),
+		},
+		{
+			name:       "Empty Retry-After falls back to exponential backoff",
+			min:        1 * time.Second,
+			max:        30 * time.Second,
+			attemptNum: 2,
+			expected:   4 * time.Second,
+			resp:       withRetryAfter(newResponse(429), ""),
+		},
+		{
+			name:       "Zero Retry-After falls back to exponential backoff",
+			min:        1 * time.Second,
+			max:        30 * time.Second,
+			attemptNum: 1,
+			expected:   2 * time.Second,
+			resp:       withRetryAfter(newResponse(429), "0"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			backoff := DefaultBackoff(test.min, test.max, test.attemptNum, test.resp)
+
+			assert.Equal(t, test.expected, backoff)
+		})
+	}
+}
+
+func newResponse(statusCode int) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+	}
+}
+
+func withRetryAfter(resp *http.Response, val string) *http.Response {
+	if resp.Header == nil {
+		resp.Header = http.Header{}
+	}
+	resp.Header.Add("Retry-After", val)
+
+	return resp
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Bonial-International-GmbH/site24x7-go
 go 1.12
 
 require (
+	github.com/hashicorp/go-retryablehttp v0.6.2
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,12 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.2 h1:bHM2aVXwBtBJWxHtkSrWuI4umABCUczs52eiUS9nSiw=
+github.com/hashicorp/go-retryablehttp v0.6.2/go.mod h1:gEx6HMUGxYYhJScX7W1Il64m6cc2C1mDaW3NQ9sY1FY=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/rest/client.go
+++ b/rest/client.go
@@ -2,6 +2,8 @@ package rest
 
 import "net/http"
 
+// Client is the interface of a rest client that can build requests for the
+// different http verbs.
 type Client interface {
 	Verb(verb string) *Request
 	Post() *Request
@@ -10,6 +12,8 @@ type Client interface {
 	Delete() *Request
 }
 
+// HTTPClient is the interface of an http client that is compatible with
+// *http.Client.
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }


### PR DESCRIPTION
This PR implements automatic backoff retry logic for retryable requests like connection errors, `5xx` server errors and `429` (TooManyRequests). If present, it will use the value in the `Retry-After` header as the retry timeout, exponential backoff otherwise.

The retry logic is transparently enabled if the client was created using `site24x7.New()`.