### PR TITLE
add fake client with fake endpoints

### DIFF
--- a/api/endpoints/fake/it_automation.go
+++ b/api/endpoints/fake/it_automation.go
@@ -1,0 +1,50 @@
+package fake
+
+import (
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+	"github.com/Bonial-International-GmbH/site24x7-go/api/endpoints"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ endpoints.ITAutomations = &ITAutomations{}
+
+type ITAutomations struct {
+	mock.Mock
+}
+
+func (e *ITAutomations) Get(actionID string) (*api.ITAutomation, error) {
+	args := e.Called(actionID)
+	if obj, ok := args.Get(0).(*api.ITAutomation); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *ITAutomations) Create(automation *api.ITAutomation) (*api.ITAutomation, error) {
+	args := e.Called(automation)
+	if obj, ok := args.Get(0).(*api.ITAutomation); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *ITAutomations) Update(automation *api.ITAutomation) (*api.ITAutomation, error) {
+	args := e.Called(automation)
+	if obj, ok := args.Get(0).(*api.ITAutomation); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *ITAutomations) Delete(actionID string) error {
+	args := e.Called(actionID)
+	return args.Error(0)
+}
+
+func (e *ITAutomations) List() ([]*api.ITAutomation, error) {
+	args := e.Called()
+	if obj, ok := args.Get(0).([]*api.ITAutomation); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}

--- a/api/endpoints/fake/location_profiles.go
+++ b/api/endpoints/fake/location_profiles.go
@@ -1,0 +1,50 @@
+package fake
+
+import (
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+	"github.com/Bonial-International-GmbH/site24x7-go/api/endpoints"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ endpoints.LocationProfiles = &LocationProfiles{}
+
+type LocationProfiles struct {
+	mock.Mock
+}
+
+func (e *LocationProfiles) Get(profileID string) (*api.LocationProfile, error) {
+	args := e.Called(profileID)
+	if obj, ok := args.Get(0).(*api.LocationProfile); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *LocationProfiles) Create(profile *api.LocationProfile) (*api.LocationProfile, error) {
+	args := e.Called(profile)
+	if obj, ok := args.Get(0).(*api.LocationProfile); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *LocationProfiles) Update(profile *api.LocationProfile) (*api.LocationProfile, error) {
+	args := e.Called(profile)
+	if obj, ok := args.Get(0).(*api.LocationProfile); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *LocationProfiles) Delete(profileID string) error {
+	args := e.Called(profileID)
+	return args.Error(0)
+}
+
+func (e *LocationProfiles) List() ([]*api.LocationProfile, error) {
+	args := e.Called()
+	if obj, ok := args.Get(0).([]*api.LocationProfile); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}

--- a/api/endpoints/fake/monitor_groups.go
+++ b/api/endpoints/fake/monitor_groups.go
@@ -1,0 +1,50 @@
+package fake
+
+import (
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+	"github.com/Bonial-International-GmbH/site24x7-go/api/endpoints"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ endpoints.MonitorGroups = &MonitorGroups{}
+
+type MonitorGroups struct {
+	mock.Mock
+}
+
+func (e *MonitorGroups) Get(groupID string) (*api.MonitorGroup, error) {
+	args := e.Called(groupID)
+	if obj, ok := args.Get(0).(*api.MonitorGroup); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *MonitorGroups) Create(group *api.MonitorGroup) (*api.MonitorGroup, error) {
+	args := e.Called(group)
+	if obj, ok := args.Get(0).(*api.MonitorGroup); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *MonitorGroups) Update(group *api.MonitorGroup) (*api.MonitorGroup, error) {
+	args := e.Called(group)
+	if obj, ok := args.Get(0).(*api.MonitorGroup); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *MonitorGroups) Delete(groupID string) error {
+	args := e.Called(groupID)
+	return args.Error(0)
+}
+
+func (e *MonitorGroups) List() ([]*api.MonitorGroup, error) {
+	args := e.Called()
+	if obj, ok := args.Get(0).([]*api.MonitorGroup); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}

--- a/api/endpoints/fake/monitors.go
+++ b/api/endpoints/fake/monitors.go
@@ -1,0 +1,50 @@
+package fake
+
+import (
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+	"github.com/Bonial-International-GmbH/site24x7-go/api/endpoints"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ endpoints.Monitors = &Monitors{}
+
+type Monitors struct {
+	mock.Mock
+}
+
+func (e *Monitors) Get(monitorID string) (*api.Monitor, error) {
+	args := e.Called(monitorID)
+	if obj, ok := args.Get(0).(*api.Monitor); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *Monitors) Create(monitor *api.Monitor) (*api.Monitor, error) {
+	args := e.Called(monitor)
+	if obj, ok := args.Get(0).(*api.Monitor); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *Monitors) Update(monitor *api.Monitor) (*api.Monitor, error) {
+	args := e.Called(monitor)
+	if obj, ok := args.Get(0).(*api.Monitor); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *Monitors) Delete(monitorID string) error {
+	args := e.Called(monitorID)
+	return args.Error(0)
+}
+
+func (e *Monitors) List() ([]*api.Monitor, error) {
+	args := e.Called()
+	if obj, ok := args.Get(0).([]*api.Monitor); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}

--- a/api/endpoints/fake/notification_profiles.go
+++ b/api/endpoints/fake/notification_profiles.go
@@ -1,0 +1,50 @@
+package fake
+
+import (
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+	"github.com/Bonial-International-GmbH/site24x7-go/api/endpoints"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ endpoints.NotificationProfiles = &NotificationProfiles{}
+
+type NotificationProfiles struct {
+	mock.Mock
+}
+
+func (e *NotificationProfiles) Get(profileID string) (*api.NotificationProfile, error) {
+	args := e.Called(profileID)
+	if obj, ok := args.Get(0).(*api.NotificationProfile); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *NotificationProfiles) Create(profile *api.NotificationProfile) (*api.NotificationProfile, error) {
+	args := e.Called(profile)
+	if obj, ok := args.Get(0).(*api.NotificationProfile); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *NotificationProfiles) Update(profile *api.NotificationProfile) (*api.NotificationProfile, error) {
+	args := e.Called(profile)
+	if obj, ok := args.Get(0).(*api.NotificationProfile); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *NotificationProfiles) Delete(profileID string) error {
+	args := e.Called(profileID)
+	return args.Error(0)
+}
+
+func (e *NotificationProfiles) List() ([]*api.NotificationProfile, error) {
+	args := e.Called()
+	if obj, ok := args.Get(0).([]*api.NotificationProfile); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}

--- a/api/endpoints/fake/threshold_profiles.go
+++ b/api/endpoints/fake/threshold_profiles.go
@@ -1,0 +1,50 @@
+package fake
+
+import (
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+	"github.com/Bonial-International-GmbH/site24x7-go/api/endpoints"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ endpoints.ThresholdProfiles = &ThresholdProfiles{}
+
+type ThresholdProfiles struct {
+	mock.Mock
+}
+
+func (e *ThresholdProfiles) Get(profileID string) (*api.ThresholdProfile, error) {
+	args := e.Called(profileID)
+	if obj, ok := args.Get(0).(*api.ThresholdProfile); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *ThresholdProfiles) Create(profile *api.ThresholdProfile) (*api.ThresholdProfile, error) {
+	args := e.Called(profile)
+	if obj, ok := args.Get(0).(*api.ThresholdProfile); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *ThresholdProfiles) Update(profile *api.ThresholdProfile) (*api.ThresholdProfile, error) {
+	args := e.Called(profile)
+	if obj, ok := args.Get(0).(*api.ThresholdProfile); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *ThresholdProfiles) Delete(profileID string) error {
+	args := e.Called(profileID)
+	return args.Error(0)
+}
+
+func (e *ThresholdProfiles) List() ([]*api.ThresholdProfile, error) {
+	args := e.Called()
+	if obj, ok := args.Get(0).([]*api.ThresholdProfile); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}

--- a/api/endpoints/fake/user_groups.go
+++ b/api/endpoints/fake/user_groups.go
@@ -1,0 +1,50 @@
+package fake
+
+import (
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+	"github.com/Bonial-International-GmbH/site24x7-go/api/endpoints"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ endpoints.UserGroups = &UserGroups{}
+
+type UserGroups struct {
+	mock.Mock
+}
+
+func (e *UserGroups) Get(groupID string) (*api.UserGroup, error) {
+	args := e.Called(groupID)
+	if obj, ok := args.Get(0).(*api.UserGroup); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *UserGroups) Create(group *api.UserGroup) (*api.UserGroup, error) {
+	args := e.Called(group)
+	if obj, ok := args.Get(0).(*api.UserGroup); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *UserGroups) Update(group *api.UserGroup) (*api.UserGroup, error) {
+	args := e.Called(group)
+	if obj, ok := args.Get(0).(*api.UserGroup); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (e *UserGroups) Delete(groupID string) error {
+	args := e.Called(groupID)
+	return args.Error(0)
+}
+
+func (e *UserGroups) List() ([]*api.UserGroup, error) {
+	args := e.Called()
+	if obj, ok := args.Get(0).([]*api.UserGroup); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}

--- a/fake/client.go
+++ b/fake/client.go
@@ -1,0 +1,69 @@
+package fake
+
+import (
+	"github.com/Bonial-International-GmbH/site24x7-go"
+	"github.com/Bonial-International-GmbH/site24x7-go/api/endpoints"
+	"github.com/Bonial-International-GmbH/site24x7-go/api/endpoints/fake"
+)
+
+var _ site24x7.Client = &Client{}
+
+// Client is an implementation of site24x7.Client that stubs out all endpoints
+// with mocks. In can be used in unit tests.
+type Client struct {
+	FakeITAutomations        *fake.ITAutomations
+	FakeLocationProfiles     *fake.LocationProfiles
+	FakeMonitorGroups        *fake.MonitorGroups
+	FakeMonitors             *fake.Monitors
+	FakeNotificationProfiles *fake.NotificationProfiles
+	FakeThresholdProfiles    *fake.ThresholdProfiles
+	FakeUserGroups           *fake.UserGroups
+}
+
+// NewClient creates a new fake site24x7 API client.
+func NewClient() *Client {
+	return &Client{
+		FakeITAutomations:        &fake.ITAutomations{},
+		FakeLocationProfiles:     &fake.LocationProfiles{},
+		FakeMonitorGroups:        &fake.MonitorGroups{},
+		FakeMonitors:             &fake.Monitors{},
+		FakeNotificationProfiles: &fake.NotificationProfiles{},
+		FakeThresholdProfiles:    &fake.ThresholdProfiles{},
+		FakeUserGroups:           &fake.UserGroups{},
+	}
+}
+
+// ItAutomations implements Client.
+func (c *Client) ITAutomations() endpoints.ITAutomations {
+	return c.FakeITAutomations
+}
+
+// LocationProfiles implements Client.
+func (c *Client) LocationProfiles() endpoints.LocationProfiles {
+	return c.FakeLocationProfiles
+}
+
+// Monitors implements Client.
+func (c *Client) Monitors() endpoints.Monitors {
+	return c.FakeMonitors
+}
+
+// MonitorGroups implements Client.
+func (c *Client) MonitorGroups() endpoints.MonitorGroups {
+	return c.FakeMonitorGroups
+}
+
+// NotificationProfiles implements Client.
+func (c *Client) NotificationProfiles() endpoints.NotificationProfiles {
+	return c.FakeNotificationProfiles
+}
+
+// ThresholdProfiles implements Client.
+func (c *Client) ThresholdProfiles() endpoints.ThresholdProfiles {
+	return c.FakeThresholdProfiles
+}
+
+// UserGroups implements Client.
+func (c *Client) UserGroups() endpoints.UserGroups {
+	return c.FakeUserGroups
+}

--- a/fake/client_test.go
+++ b/fake/client_test.go
@@ -1,0 +1,36 @@
+package fake
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientMonitorsCreate(t *testing.T) {
+	c := NewClient()
+
+	monitor := &api.Monitor{
+		DisplayName: "foo",
+	}
+
+	c.FakeMonitors.On("Create", mock.Anything).Return(monitor, nil).Once()
+	c.FakeMonitors.On("Create", mock.Anything).Return(nil, errors.New("whoops")).Once()
+
+	result, err := c.Monitors().Create(&api.Monitor{})
+
+	require.NoError(t, err)
+
+	assert.Equal(t, monitor, result)
+
+	_, err = c.Monitors().Create(&api.Monitor{})
+
+	require.Error(t, err)
+
+	assert.Equal(t, errors.New("whoops"), err)
+
+	c.FakeMonitors.AssertExpectations(t)
+}

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=


### PR DESCRIPTION
This is useful for consumers of this package who want to stub out calls
to the site24x7 client in tests.