### PR TITLE
Feature: check location IP lookup support for location profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Refer to the
 all available endpoints and
 [API types](https://godoc.org/github.com/Bonial-International-GmbH/site24x7-go/api).
 
+Also check out the other usage examples in the [_examples/](_examples/) subdirectory.
+
 License
 -------
 

--- a/_examples/location-ips/main.go
+++ b/_examples/location-ips/main.go
@@ -17,6 +17,10 @@ func main() {
 
 	client := site24x7.New(config)
 
+	// Using the ProfileIPProvider it is possible to retrieve a list of all IP
+	// addresses associated with the locations of a LocationProfile. This is
+	// useful it you want to do dynamic server-side IP whitelisting of Site24x7
+	// check origins.
 	ipProvider, err := location.NewDefaultProfileIPProvider(client)
 	if err != nil {
 		panic(err)
@@ -28,6 +32,8 @@ func main() {
 	}
 
 	for _, profile := range profiles {
+		// This will lookup all IP addresses associated to the locations
+		// configured in the location profile.
 		ips, err := ipProvider.GetLocationIPs(profile)
 		if err != nil {
 			panic(err)

--- a/_examples/location-ips/main.go
+++ b/_examples/location-ips/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	site24x7 "github.com/Bonial-International-GmbH/site24x7-go"
+	"github.com/Bonial-International-GmbH/site24x7-go/location"
+)
+
+func main() {
+	config := site24x7.Config{
+		ClientID:     os.Getenv("CLIENT_ID"),
+		ClientSecret: os.Getenv("CLIENT_SECRET"),
+		RefreshToken: os.Getenv("REFRESH_TOKEN"),
+	}
+
+	client := site24x7.New(config)
+
+	ipProvider, err := location.NewDefaultProfileIPProvider(client)
+	if err != nil {
+		panic(err)
+	}
+
+	profiles, err := client.LocationProfiles().List()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, profile := range profiles {
+		ips, err := ipProvider.GetLocationIPs(profile)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("%s:\n", profile.ProfileName)
+		for _, ip := range ips {
+			fmt.Printf("  %s\n", ip)
+		}
+		fmt.Println()
+	}
+}

--- a/api/endpoints/fake/location_template.go
+++ b/api/endpoints/fake/location_template.go
@@ -1,0 +1,21 @@
+package fake
+
+import (
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+	"github.com/Bonial-International-GmbH/site24x7-go/api/endpoints"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ endpoints.LocationTemplate = &LocationTemplate{}
+
+type LocationTemplate struct {
+	mock.Mock
+}
+
+func (e *LocationTemplate) Get() (*api.LocationTemplate, error) {
+	args := e.Called()
+	if obj, ok := args.Get(0).(*api.LocationTemplate); ok {
+		return obj, args.Error(1)
+	}
+	return nil, args.Error(1)
+}

--- a/api/endpoints/location_template.go
+++ b/api/endpoints/location_template.go
@@ -1,0 +1,31 @@
+package endpoints
+
+import (
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+	"github.com/Bonial-International-GmbH/site24x7-go/rest"
+)
+
+type LocationTemplate interface {
+	Get() (*api.LocationTemplate, error)
+}
+
+type locationTemplate struct {
+	client rest.Client
+}
+
+func NewLocationTemplate(client rest.Client) LocationTemplate {
+	return &locationTemplate{
+		client: client,
+	}
+}
+
+func (c *locationTemplate) Get() (*api.LocationTemplate, error) {
+	template := &api.LocationTemplate{}
+	err := c.client.
+		Get().
+		Resource("location_template").
+		Do().
+		Into(&template)
+
+	return template, err
+}

--- a/api/types.go
+++ b/api/types.go
@@ -88,6 +88,25 @@ type LocationProfile struct {
 	RestrictAltLoc     bool     `json:"restrict_alt_loc"`
 }
 
+// LocationTemplate holds locations Site24x7 performs their monitor checks
+// from.
+type LocationTemplate struct {
+	Locations []*Location `json:"locations"`
+}
+
+// Location is a physical location Site24x7 performs monitor checks from. The
+// LocationID field maps to the IDs used in the PrimaryLocation and
+// SecondaryLocations fields of LocationProfile values.
+type Location struct {
+	LocationID  string `json:"location_id"`
+	CountryName string `json:"country_name"`
+	DisplayName string `json:"display_name"`
+	UseIPV6     bool   `json:"use_ipv6"`
+	CityName    string `json:"city_name"`
+	CityShort   string `json:"city_short"`
+	Continent   string `json:"continent"`
+}
+
 // ThresholdProfile help the alarms engine to decide if a specific resource has to be declared critical or down
 type ThresholdProfile struct {
 	ProfileID              string `json:"profile_id,omitempty"`

--- a/client.go
+++ b/client.go
@@ -53,6 +53,7 @@ type HTTPClient interface {
 // clients for resource endpoints.
 type Client interface {
 	LocationProfiles() endpoints.LocationProfiles
+	LocationTemplate() endpoints.LocationTemplate
 	MonitorGroups() endpoints.MonitorGroups
 	Monitors() endpoints.Monitors
 	NotificationProfiles() endpoints.NotificationProfiles
@@ -87,6 +88,11 @@ func NewClient(httpClient HTTPClient) Client {
 // LocationProfiles implements Client.
 func (c *client) LocationProfiles() endpoints.LocationProfiles {
 	return endpoints.NewLocationProfiles(c.restClient)
+}
+
+// LocationTemplate implements Client.
+func (c *client) LocationTemplate() endpoints.LocationTemplate {
+	return endpoints.NewLocationTemplate(c.restClient)
 }
 
 // Monitors implements Client.

--- a/fake/client.go
+++ b/fake/client.go
@@ -12,6 +12,7 @@ var _ site24x7.Client = &Client{}
 // with mocks. In can be used in unit tests.
 type Client struct {
 	FakeITAutomations        *fake.ITAutomations
+	FakeLocationTemplate     *fake.LocationTemplate
 	FakeLocationProfiles     *fake.LocationProfiles
 	FakeMonitorGroups        *fake.MonitorGroups
 	FakeMonitors             *fake.Monitors
@@ -25,6 +26,7 @@ func NewClient() *Client {
 	return &Client{
 		FakeITAutomations:        &fake.ITAutomations{},
 		FakeLocationProfiles:     &fake.LocationProfiles{},
+		FakeLocationTemplate:     &fake.LocationTemplate{},
 		FakeMonitorGroups:        &fake.MonitorGroups{},
 		FakeMonitors:             &fake.Monitors{},
 		FakeNotificationProfiles: &fake.NotificationProfiles{},
@@ -41,6 +43,11 @@ func (c *Client) ITAutomations() endpoints.ITAutomations {
 // LocationProfiles implements Client.
 func (c *Client) LocationProfiles() endpoints.LocationProfiles {
 	return c.FakeLocationProfiles
+}
+
+// LocationTemplate implements Client.
+func (c *Client) LocationTemplate() endpoints.LocationTemplate {
+	return c.FakeLocationTemplate
 }
 
 // Monitors implements Client.

--- a/location/dns_ip_source_test.go
+++ b/location/dns_ip_source_test.go
@@ -1,0 +1,86 @@
+// +build integration
+
+package location
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDNSIPSource(t *testing.T) {
+	tests := []struct {
+		name        string
+		location    *api.Location
+		expectedErr error
+	}{
+		{
+			name: "lookup one word",
+			location: &api.Location{
+				LocationID:  "66",
+				DisplayName: "Helsinki - FI",
+				CityName:    "Helsinki",
+			},
+		},
+		{
+			name: "lookup multiword",
+			location: &api.Location{
+				LocationID:  "15",
+				DisplayName: "Tel Aviv - IL",
+				CityName:    "Tel Aviv",
+			},
+		},
+		{
+			name: "lookup multiword",
+			location: &api.Location{
+				LocationID:  "15",
+				DisplayName: "Tel Aviv - IL",
+				CityName:    "Tel Aviv",
+			},
+		},
+		{
+			name: "lookup multiword edge case",
+			location: &api.Location{
+				LocationID:  "16",
+				DisplayName: "Rio de Janeiro - BR",
+				CityName:    "Rio de Janeiro",
+			},
+		},
+		{
+			name: "lookup invalid multiword",
+			location: &api.Location{
+				LocationID:  "42",
+				DisplayName: "Foo Bar Baz - DE",
+				CityName:    "Foo Bar Baz",
+			},
+			expectedErr: errors.New(`failed to lookup IPs for location "Foo Bar Baz - DE": lookup foo-de.enduserexp.com: no such host`),
+		},
+		{
+			name: "missing country code",
+			location: &api.Location{
+				LocationID:  "1",
+				DisplayName: "Frankfurt",
+				CityName:    "Frankfurt",
+			},
+			expectedErr: errors.New(`failed to parse country code from location name "Frankfurt"`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := NewDefaultDNSIPSource()
+
+			ips, err := s.LookupIPs(test.location)
+			if test.expectedErr != nil {
+				require.Error(t, err)
+				assert.Equal(t, test.expectedErr.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+				assert.NotEmpty(t, ips)
+			}
+		})
+	}
+}

--- a/location/ip_source.go
+++ b/location/ip_source.go
@@ -1,0 +1,133 @@
+package location
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+)
+
+const (
+	// DefaultBaseDNSDomain is the domain where all Site24x7 check location
+	// IPs are aggregated under.
+	DefaultBaseDNSDomain = "enduserexp.com"
+)
+
+// IPSource provides the origin IP addresses for a Site24x7 check location.
+type IPSource interface {
+	// LookupIPs looks up all Site24x7 IPs associated with given location. The
+	// resulting slice of net.IP values can be used for whitelisting IP addresses
+	// in the firewalls of the endpoints monitors are configured for.
+	LookupIPs(location *api.Location) ([]string, error)
+}
+
+// StaticIPSource looks up check location IPs from a static map.
+type StaticIPSource struct {
+	// LocationIPs is a mapping between location ID and the list of IP
+	// addresses associated with this location.
+	LocationIPs map[string][]string
+}
+
+// LookupIPs implements IPSource.
+func (s *StaticIPSource) LookupIPs(location *api.Location) ([]string, error) {
+	return s.LocationIPs[location.LocationID], nil
+}
+
+// DNSIPSource looks up check location IPs using DNS.
+type DNSIPSource struct {
+	// BaseDNSDomain is the DNS domain the aggregates all check location IPs
+	// under subdomains with the naming scheme {{CityName}}-{{CountryCode}}.
+	BaseDNSDomain string
+}
+
+// NewDefaultDNSIPSource creates a new *DNSIPSource value for the default
+// BaseDNSDomain.
+func NewDefaultDNSIPSource() *DNSIPSource {
+	return &DNSIPSource{
+		BaseDNSDomain: DefaultBaseDNSDomain,
+	}
+}
+
+// LookupIPs implements IPSource.
+func (s *DNSIPSource) LookupIPs(location *api.Location) ([]string, error) {
+	countryCode, err := parseCountryCode(location)
+	if err != nil {
+		return nil, err
+	}
+
+	ips, err := s.lookupIPs(location.CityName, countryCode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup IPs for location %q: %v", location.DisplayName, err)
+	}
+
+	return netIPsToStrings(ips), nil
+}
+
+// lookupIPs performs IP lookup by city and country code and tries to handle
+// some inconsistencies in the naming of the city specific DNS subdomains.
+//
+// This builds the DNS name that resolves to all IP addresses
+// for given location. DNS names have the following form:
+//
+//   {{CityName}}-{{CountryCode}}.enduserexp.com
+//
+// For example, the DNS name for `Tel Aviv` in Israel is:
+//
+//   telaviv-il.enduserexp.com
+//
+// However, the DNS name for `Rio de Janeiro` in Brazil is not:
+//
+//   riodejaneiro-br.enduserexp.com
+//
+// but rather
+//
+//    rio-br.enduserexp.com
+//
+// For these cases, the following sequence of DNS lookups is attempted, bailing
+// out on the first successful one:
+//
+//   1. riodejaneiro-br.enduserexp.com
+//   2. riode-br.enduserexp.com
+//   3. rio-br.enduserexp.com
+func (s *DNSIPSource) lookupIPs(cityName string, countryCode string) (ips []net.IP, err error) {
+	words := strings.Split(cityName, " ")
+
+	for len(words) > 0 {
+		cityName := strings.Join(words, "")
+		host := fmt.Sprintf("%s-%s.%s", strings.ToLower(cityName), countryCode, s.BaseDNSDomain)
+
+		ips, err = net.LookupIP(host)
+		if err == nil {
+			break
+		}
+
+		words = words[0 : len(words)-1]
+	}
+
+	return ips, err
+}
+
+func netIPsToStrings(netIPs []net.IP) []string {
+	ips := make([]string, len(netIPs))
+	for i, ip := range netIPs {
+		if len(ip) == 0 {
+			continue
+		}
+
+		ips[i] = ip.String()
+	}
+
+	return ips
+}
+
+// parseCountryCode parses the country code from the locations' display name.
+// The display name has the format: {{CityName}} - {{CountryCode}}.
+func parseCountryCode(location *api.Location) (string, error) {
+	parts := strings.Split(location.DisplayName, " - ")
+	if len(parts) != 2 || parts[1] == "" {
+		return "", fmt.Errorf("failed to parse country code from location name %q", location.DisplayName)
+	}
+
+	return strings.ToLower(parts[1]), nil
+}

--- a/location/location_test.go
+++ b/location/location_test.go
@@ -1,0 +1,78 @@
+package location
+
+import (
+	"testing"
+
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProfileIPProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		locations   []*api.Location
+		locationIPs map[string][]string
+		profile     *api.LocationProfile
+		expected    []string
+		expectedErr error
+	}{
+		{
+			name: "looks up IPs for primary location",
+			locations: []*api.Location{
+				{LocationID: "123"},
+			},
+			locationIPs: map[string][]string{
+				"123": []string{"1.2.3.4", "5.6.7.8"},
+			},
+			profile: &api.LocationProfile{
+				PrimaryLocation: "123",
+			},
+			expected: []string{"1.2.3.4", "5.6.7.8"},
+		},
+		{
+			name: "looks up IPs for primary and secondary locations",
+			locations: []*api.Location{
+				{LocationID: "123"},
+				{LocationID: "456"},
+				{LocationID: "789"},
+			},
+			locationIPs: map[string][]string{
+				"123": []string{"127.0.0.1"},
+				"456": []string{"1.2.3.4", "5.6.7.8"},
+				"789": []string{"1.1.1.1"},
+			},
+			profile: &api.LocationProfile{
+				PrimaryLocation:    "456",
+				SecondaryLocations: []string{"123", "789"},
+			},
+			expected: []string{"1.2.3.4", "5.6.7.8", "127.0.0.1", "1.1.1.1"},
+		},
+		{
+			name: "unknown locations produce empty ip list",
+			profile: &api.LocationProfile{
+				PrimaryLocation: "123",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := &ProfileIPProvider{
+				Locations: test.locations,
+				IPSource: &StaticIPSource{
+					LocationIPs: test.locationIPs,
+				},
+			}
+
+			ips, err := p.GetLocationIPs(test.profile)
+			if test.expectedErr != nil {
+				require.Error(t, err)
+				assert.Equal(t, test.expectedErr.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected, ips)
+			}
+		})
+	}
+}

--- a/location/profile_ip_provider.go
+++ b/location/profile_ip_provider.go
@@ -1,0 +1,64 @@
+package location
+
+import (
+	site24x7 "github.com/Bonial-International-GmbH/site24x7-go"
+	"github.com/Bonial-International-GmbH/site24x7-go/api"
+)
+
+// ProfileIPProvider provides the check location IP addresses for location
+// profiles.
+type ProfileIPProvider struct {
+	Locations []*api.Location
+	IPSource  IPSource
+}
+
+// NewDefaultProfileIPProvider creates a new *ProfileIPProvider which performs
+// IP lookups via DNS. The available locations are obtained via the
+// site24x7.Client. Returns an error of retrieving the location list fails.
+func NewDefaultProfileIPProvider(client site24x7.Client) (*ProfileIPProvider, error) {
+	locationTemplate, err := client.LocationTemplate().Get()
+	if err != nil {
+		return nil, err
+	}
+
+	p := &ProfileIPProvider{
+		Locations: locationTemplate.Locations,
+		IPSource:  NewDefaultDNSIPSource(),
+	}
+
+	return p, nil
+}
+
+// GetLocationIPs performs a lookup of the check IPs of all primary and
+// secondary locations associated with the location profile.
+func (p *ProfileIPProvider) GetLocationIPs(profile *api.LocationProfile) ([]string, error) {
+	locationIDs := append([]string{profile.PrimaryLocation}, profile.SecondaryLocations...)
+
+	var ips []string
+
+	for _, locationID := range locationIDs {
+		location, found := p.getLocation(locationID)
+		if !found {
+			continue
+		}
+
+		locationIPs, err := p.IPSource.LookupIPs(location)
+		if err != nil {
+			return nil, err
+		}
+
+		ips = append(ips, locationIPs...)
+	}
+
+	return ips, nil
+}
+
+func (p *ProfileIPProvider) getLocation(locationID string) (*api.Location, bool) {
+	for _, location := range p.Locations {
+		if location.LocationID == locationID {
+			return location, true
+		}
+	}
+
+	return nil, false
+}


### PR DESCRIPTION
This PR implements lookup of the IP addresses of all locations configured in a location profile. This allows for dynamic whitelisting of Site24x7 check origins based on the locations the checks are performed from.

Check out the following usage example that is bundled with this PR:
https://github.com/Bonial-International-GmbH/site24x7-go/blob/feature/locations/_examples/location-ips/main.go

Full list of changes:
- Add `LocationTemplate` and `Location` API types.
- Add `LocationTemplate` endpoint for obtaining metadata for location IDs used in location profiles (https://www.site24x7.com/help/api/#location-ids).
- Fakes for the `LocationTemplate` endpoint.
- Add `location` package which provides the following tools:
  - `IPSource` interface for supporting multiple sources for the Site24x7 location origin IP lookup.
  - `DNSIPSource` implements DNS based lookup of location IPs as explained here: https://support.site24x7.com/portal/kb/articles/domain-configurations-for-location-server-ips
  - `StaticIPSource` implements IP lookup based on a static location ID to IP list mapping (mostly useful in test cases).
  - `ProfileIPProvider` implements lookup of all IP addresses associated with a location profile. This uses an `IPSource` underneath.