### PR TITLE
handle expires_in RFC6749 violation

### DIFF
--- a/oauth/token.go
+++ b/oauth/token.go
@@ -1,0 +1,52 @@
+package oauth
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// maxExpiresIn is the maximum value for the expires_in field that is treated
+// as ok. Any value larger than that is considered as a broken expiry duration
+// and will be handled by tokenSource.
+const maxExpiresIn = 1 * time.Hour
+
+// tokenSource only exists due to the fact that the Site24x7 OAuth
+// Authorization Server is not compliant with RFC 6749. It returns milliseconds
+// in the expires_in field although it must return an expiry in seconds or omit
+// the field altogether (see https://tools.ietf.org/html/rfc6749#section-5.1).
+type tokenSource struct {
+	delegate oauth2.TokenSource
+	mu       sync.Mutex
+}
+
+// Token implements oauth2.TokenSource.
+func (s *tokenSource) Token() (*oauth2.Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	token, err := s.delegate.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	// The Site24x7 OAuth Authorization Server hands out access tokens with a
+	// lifetime of one hour. Since it reports milliseconds instead of seconds
+	// in the expires_in field, the automatic token refresh mechanism is
+	// broken.
+	// We detect tokens with a wrong expiry based on the fact that it is way
+	// beyond one hour from now.
+	if time.Until(token.Expiry) > maxExpiresIn {
+		// This is a hack which is better than forking golang.org/x/oauth2 and
+		// "fixing" it by violating the RFC:
+		// Because token is a pointer which is shared with the token source
+		// that we are delegating to, we can manipulate it to fix validity
+		// checks in our delegates. Subsequent calls to s.delegate.Token() will
+		// check the validity based on the fixed expiry date and refresh the
+		// token if needed.
+		token.Expiry = time.Now().Add(maxExpiresIn)
+	}
+
+	return token, nil
+}

--- a/oauth/token_test.go
+++ b/oauth/token_test.go
@@ -1,0 +1,69 @@
+package oauth
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestTokenSource_Token(t *testing.T) {
+	brokenToken := &oauth2.Token{
+		AccessToken: "foobar",
+		Expiry:      time.Now().Add(maxExpiresIn * 1000), // off by one magnitude
+	}
+
+	ts := &tokenSource{
+		delegate: oauth2.StaticTokenSource(brokenToken),
+	}
+
+	// first call fixes the expiry time
+	token, err := ts.Token()
+	require.NoError(t, err)
+
+	expiry := token.Expiry
+
+	assert.True(t, time.Until(expiry) <= maxExpiresIn)
+	assert.Equal(t, token, brokenToken)
+
+	// subsequent calls do not update the exipry time
+	token, err = ts.Token()
+	require.NoError(t, err)
+
+	assert.Equal(t, expiry, token.Expiry)
+}
+
+func TestTokenSource_Token_expired(t *testing.T) {
+	expiredToken := &oauth2.Token{
+		AccessToken: "foobar",
+		Expiry:      time.Now(),
+	}
+
+	ts := &tokenSource{
+		delegate: oauth2.StaticTokenSource(expiredToken),
+	}
+
+	token, err := ts.Token()
+	require.NoError(t, err)
+
+	assert.False(t, token.Valid())
+}
+
+type badTokenSource struct{}
+
+func (*badTokenSource) Token() (*oauth2.Token, error) {
+	return nil, errors.New("whoops")
+}
+
+func TestTokenSource_Token_error(t *testing.T) {
+	ts := &tokenSource{
+		delegate: &badTokenSource{},
+	}
+
+	_, err := ts.Token()
+	require.Error(t, err)
+	assert.Equal(t, errors.New("whoops"), err)
+}


### PR DESCRIPTION
Site24x7 specifies the value in the `expires_in` field of the token
response in milliseconds although it must be provided in seconds (e.g.
3600000 instead of 3600 for a validity of one hour). This is a violation
of RFC6749 (see https://tools.ietf.org/html/rfc6749#section-5.1) and
prevents the token refresh mechanism from functioning properly as an
actual validity of one hour is returned as 41.6 days by the Site24x7
OAuth Authorization Server. This makes an instance of the API client
unusable after running for longer than an hour.

This patch implements a token source which handles malformed token
expiry dates and fixes them. It also sets the `AuthStyle` for the OAuth
endpoint to `oauth2.AuthStyleInParams` to avoid the probing round trip.