### PR TITLE
add endpoints for activate/suspend monitor

### DIFF
--- a/api/endpoints/fake/monitors.go
+++ b/api/endpoints/fake/monitors.go
@@ -48,3 +48,13 @@ func (e *Monitors) List() ([]*api.Monitor, error) {
 	}
 	return nil, args.Error(1)
 }
+
+func (e *Monitors) Activate(monitorID string) error {
+	args := e.Called(monitorID)
+	return args.Error(0)
+}
+
+func (e *Monitors) Suspend(monitorID string) error {
+	args := e.Called(monitorID)
+	return args.Error(0)
+}

--- a/api/endpoints/monitors.go
+++ b/api/endpoints/monitors.go
@@ -11,6 +11,8 @@ type Monitors interface {
 	Update(monitor *api.Monitor) (*api.Monitor, error)
 	Delete(monitorID string) error
 	List() ([]*api.Monitor, error)
+	Activate(monitorID string) error
+	Suspend(monitorID string) error
 }
 
 type monitors struct {
@@ -80,4 +82,22 @@ func (c *monitors) List() ([]*api.Monitor, error) {
 		Into(&monitors)
 
 	return monitors, err
+}
+
+func (c *monitors) Activate(monitorID string) error {
+	return c.client.
+		Put().
+		Resource("monitors/activate").
+		ResourceID(monitorID).
+		Do().
+		Err()
+}
+
+func (c *monitors) Suspend(monitorID string) error {
+	return c.client.
+		Put().
+		Resource("monitors/suspend").
+		ResourceID(monitorID).
+		Do().
+		Err()
 }


### PR DESCRIPTION
See API documentation: https://www.site24x7.com/help/api/#activate-monitor

We will need these for porting the monitor recheck job to Go.