### PR TITLE
Work around bug in Site24x7 API that returns severity as a string

### DIFF
--- a/api/endpoints/testdata/fixtures/responses/get_monitor.json
+++ b/api/endpoints/testdata/fixtures/responses/get_monitor.json
@@ -44,7 +44,7 @@
     "notification_profile_id": "123412341234123413",
     "http_method": "P",
     "matching_keyword": {
-      "severity": 0,
+      "severity": "0",
       "value": "Title"
     },
     "action_ids": [

--- a/api/types.go
+++ b/api/types.go
@@ -1,6 +1,35 @@
 package api
 
+import (
+	"encoding/json"
+	"strconv"
+)
+
 type Status int
+
+// Custom unmarshaller that allows the value to be both a
+// string and an integer, always unmarshals into integer
+//
+// The Site24x7 API has a bug where it accepts integers, but
+// returns them as strings.
+func (status *Status) UnmarshalJSON(rawValue []byte) error {
+	if rawValue[0] != '"' {
+		return json.Unmarshal(rawValue, (*int)(status))
+	}
+
+	var valueAsString string
+	if err := json.Unmarshal(rawValue, &valueAsString); err != nil {
+		return err
+	}
+
+	valueAsInt, err := strconv.Atoi(valueAsString)
+	if err != nil {
+		return err
+	}
+
+	*status = Status(valueAsInt)
+	return nil
+}
 
 const (
 	Down               Status = 0


### PR DESCRIPTION
The API still accepts integers as input, but returns the severity value
as a string. Unmarshalling fails. Just adding `"severity,string"` in
the struct is not ok because that would also marshal the field as
a string.

The custom unmarshaller will handle conversion from a string to an
integer if needed. In case Site24x7 fixes their API, this will continue
working.

This fixes: https://github.com/Bonial-International-GmbH/terraform-provider-site24x7/issues/19