### PR TITLE
Add support for other API TLDs in addition to .com

### DIFF
--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -2,16 +2,13 @@ package oauth
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"golang.org/x/oauth2"
 )
 
 const (
-	// TokenURL is the URL from where access tokens for the Site24x7 API are
-	// obtained.
-	TokenURL = "https://accounts.zoho.com/oauth/v2/token"
-
 	// TokenType is the type used in the Authorization header next to the
 	// access token.
 	TokenType = "Zoho-oauthtoken"
@@ -28,7 +25,9 @@ type Config struct {
 }
 
 // NewConfig creates a new *Config for the provided client credentials.
-func NewConfig(clientID, clientSecret, refreshToken string) *Config {
+func NewConfig(clientID, clientSecret, refreshToken, apiTld string) *Config {
+	var TokenURL = fmt.Sprintf("https://accounts.zoho.%s/oauth/v2/token", apiTld)
+
 	return &Config{
 		Config: &oauth2.Config{
 			ClientID:     clientID,


### PR DESCRIPTION
Site24x7 has multiple data centres around the world, and one has to use region specific API endpoints (top-level domains) to be able to use OAuth credentials created for specific region.

This patch adds support for a config option to allow using also other data centres, in addition to the US -one. 

For backwards compatibility, it defaults to "com" if config field is not explicitly specified.